### PR TITLE
Add zlap to Command Line and Argument Parser section

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [kioz-wang/zargs](https://github.com/kioz-wang/zargs) - Another Comptime-argparse for Zig.
 - [xcaeser/zli](https://github.com/xcaeser/zli) - Zig command-line interfaces made easy. A blazing fast CLI framework. Build ergonomic, high-performance command-line tools with Zig.
 - [CogitatorTech/chilli](https://github.com/CogitatorTech/chilli) - Chilli 🌶️ is a minimalistic CLI framework for Zig.
-- [plutowang/zlap](https://github.com/plutowang/zlap) - A declarative, fluent, and type-safe command-line argument parser with subcommand support (inspired by clap).
+- [plutowang/zlap](https://github.com/plutowang/zlap) - A declarative, fluent, and type-safe command-line argument parser for Zig with subcommand support, inspired by Rust's clap.
 
 ### Finite State Machine
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [kioz-wang/zargs](https://github.com/kioz-wang/zargs) - Another Comptime-argparse for Zig.
 - [xcaeser/zli](https://github.com/xcaeser/zli) - Zig command-line interfaces made easy. A blazing fast CLI framework. Build ergonomic, high-performance command-line tools with Zig.
 - [CogitatorTech/chilli](https://github.com/CogitatorTech/chilli) - Chilli 🌶️ is a minimalistic CLI framework for Zig.
+- [plutowang/zlap](https://github.com/plutowang/zlap) - A declarative, fluent, and type-safe command-line argument parser with subcommand support (inspired by clap).
 
 ### Finite State Machine
 


### PR DESCRIPTION
Hi! 

I'd like to submit [plutowang/zlap](https://github.com/plutowang/zlap), a new command-line argument parser for Zig, to the list. 

Since the Zig ecosystem is growing rapidly, I wanted to provide a modern, declarative, and type-safe alternative (inspired by Rust's `clap`) that supports subcommands and auto-generated help messages out of the box.

(I have run `make all` locally as requested in the guidelines.)

Thanks for maintaining this awesome list! Let me know if you need any adjustments.