### PR TITLE
Add nanobrew to package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [deatil/zig-dotenv](https://github.com/deatil/zig-dotenv) - A parse and set env library for Zig.
 - [ktarasov/zigrep](https://github.com/ktarasov/zigrep) - A training project on the implementation of the similarity of the grep utility in Linux in the Zig language.
 - [hspak/geteltorito-zig](https://github.com/hspak/geteltorito-zig) - Re-write of geteltorito in Zig.
+- [justrach/nanobrew](https://github.com/justrach/nanobrew) - A fast macOS package manager written in Zig.
 - [NilsIrl/dockerc](https://github.com/NilsIrl/dockerc) - Container image to single executable compiler.
 - [shepherdjerred/macos-cross-compiler](https://github.com/shepherdjerred/macos-cross-compiler) - Cross-compilation toolchain for Zig users to compile binaries for macOS on Linux.
 - [rockorager/zzdoc](https://github.com/rockorager/zzdoc) - A scdoc-compatible manpage compiler for use in build.zig.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [joachimschmidt557/zigpkgs](https://github.com/joachimschmidt557/zigpkgs) - A collection of Zig packages built with Nix.
 - [lispking/zvm](https://github.com/lispking/zvm) - A fast, dependency-free version manager for Zig written in Zig.
 - [nektro/zigmod](https://github.com/nektro/zigmod) - A package manager for the Zig programming language.
+- [justrach/nanobrew](https://github.com/justrach/nanobrew) - A fast macOS package manager written in Zig.
 - [vezel-dev/zig-sdk](https://github.com/vezel-dev/zig-sdk) - An MSBuild SDK for building Zig, C, and C++ projects using the Zig compiler.
 - [tristanisham/zvm](https://github.com/tristanisham/zvm) - Lets you easily install/upgrade between different versions of Zig. ZLS install can be included. (written in Go).
 - [rosarp/nu-zigup](https://github.com/rosarp/nu-zigup) - Download & manage Zig compilers & zls binaries. Script is written in nushell.
@@ -158,7 +159,6 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [deatil/zig-dotenv](https://github.com/deatil/zig-dotenv) - A parse and set env library for Zig.
 - [ktarasov/zigrep](https://github.com/ktarasov/zigrep) - A training project on the implementation of the similarity of the grep utility in Linux in the Zig language.
 - [hspak/geteltorito-zig](https://github.com/hspak/geteltorito-zig) - Re-write of geteltorito in Zig.
-- [justrach/nanobrew](https://github.com/justrach/nanobrew) - A fast macOS package manager written in Zig.
 - [NilsIrl/dockerc](https://github.com/NilsIrl/dockerc) - Container image to single executable compiler.
 - [shepherdjerred/macos-cross-compiler](https://github.com/shepherdjerred/macos-cross-compiler) - Cross-compilation toolchain for Zig users to compile binaries for macOS on Linux.
 - [rockorager/zzdoc](https://github.com/rockorager/zzdoc) - A scdoc-compatible manpage compiler for use in build.zig.


### PR DESCRIPTION
## Summary

- Add justrach/nanobrew to the Utility section as a Zig-written macOS package manager.

## References

- https://github.com/justrach/nanobrew

