### PR TITLE
Add hendriknielaender/zvm to Package and Version Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [tristanisham/zvm](https://github.com/tristanisham/zvm) - Lets you easily install/upgrade between different versions of Zig. ZLS install can be included. (written in Go).
 - [rosarp/nu-zigup](https://github.com/rosarp/nu-zigup) - Download & manage Zig compilers & zls binaries. Script is written in nushell.
 - [weezy20/zv](https://github.com/weezy20/zv) - Fast Zig/ZLS version manager + project starter kit written in Rust. Binaries available for macOS/Windows/Linux.
-- [hendriknielaender/zvm](https://github.com/hendriknielaender/zvm) - POSIX-compliant fast and simple Zig version manager.
+- [hendriknielaender/zvm](https://github.com/hendriknielaender/zvm) - A fast and simple Zig version manager written in Zig.
 
 ### Utility
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [tristanisham/zvm](https://github.com/tristanisham/zvm) - Lets you easily install/upgrade between different versions of Zig. ZLS install can be included. (written in Go).
 - [rosarp/nu-zigup](https://github.com/rosarp/nu-zigup) - Download & manage Zig compilers & zls binaries. Script is written in nushell.
 - [weezy20/zv](https://github.com/weezy20/zv) - Fast Zig/ZLS version manager + project starter kit written in Rust. Binaries available for macOS/Windows/Linux.
+- [hendriknielaender/zvm](https://github.com/hendriknielaender/zvm) - POSIX-compliant fast and simple zig version manager.
 
 ### Utility
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [tristanisham/zvm](https://github.com/tristanisham/zvm) - Lets you easily install/upgrade between different versions of Zig. ZLS install can be included. (written in Go).
 - [rosarp/nu-zigup](https://github.com/rosarp/nu-zigup) - Download & manage Zig compilers & zls binaries. Script is written in nushell.
 - [weezy20/zv](https://github.com/weezy20/zv) - Fast Zig/ZLS version manager + project starter kit written in Rust. Binaries available for macOS/Windows/Linux.
-- [hendriknielaender/zvm](https://github.com/hendriknielaender/zvm) - POSIX-compliant fast and simple zig version manager.
+- [hendriknielaender/zvm](https://github.com/hendriknielaender/zvm) - POSIX-compliant fast and simple Zig version manager.
 
 ### Utility
 


### PR DESCRIPTION
Added `hendriknielaender/zvm` to the package managers list. 

I noticed there are already two other `zvm` listed, but this one is POSIX-compliant, actively maintained, and actually has more stars/traction. 

Attaching a screenshot of the repo stats below for reference.

<img width="2147" height="1156" alt="图片" src="https://github.com/user-attachments/assets/2e18647f-afdb-41e2-a562-8cdf1464c241" />
