### PR TITLE
Add AI inference stack: safetensors-zig, tokenizers-zig, vllm-zig, faiss-zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,10 +569,10 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [nullclaw/nullclaw](https://github.com/nullclaw/nullclaw) - Fastest, smallest, and fully autonomous AI assistant infrastructure written in Zig.
 - [ollama-zig](https://github.com/dravenk/ollama-zig) - Ollama Zig library.
 - [renerocksai/gpt4all.zig](https://github.com/renerocksai/gpt4all.zig) - Zig build for a terminal-based chat client for an assistant-style large language model with ~800k GPT-3.5-Turbo Generations based on LLaMA.
+- [SMC17/faiss-zig](https://github.com/SMC17/faiss-zig) - Pure-Zig vector similarity search; Flat + HNSW + IVFFlat + IVFPQ. AGPL-3.0.
 - [SMC17/safetensors-zig](https://github.com/SMC17/safetensors-zig) - Pure-Zig HuggingFace safetensors reader; ~5x faster than the Rust upstream on Llama-shape parse fixtures. AGPL-3.0.
 - [SMC17/tokenizers-zig](https://github.com/SMC17/tokenizers-zig) - Pure-Zig HuggingFace tokenizers covering BPE / WordPiece / Unigram with full HF Encoding parity, sub-token offsets, and a 600-iter property fuzz. AGPL-3.0.
 - [SMC17/vllm-zig](https://github.com/SMC17/vllm-zig) - LLM serving substrate. Real TinyLlama forward pass through Zig kernels: RoPE + GQA + KV cache + multi-thread SIMD matmul + streaming. AGPL-3.0.
-- [SMC17/faiss-zig](https://github.com/SMC17/faiss-zig) - Pure-Zig vector similarity search; Flat + HNSW + IVFFlat + IVFPQ. AGPL-3.0.
 
 ### Machine Learning
 

--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [nullclaw/nullclaw](https://github.com/nullclaw/nullclaw) - Fastest, smallest, and fully autonomous AI assistant infrastructure written in Zig.
 - [ollama-zig](https://github.com/dravenk/ollama-zig) - Ollama Zig library.
 - [renerocksai/gpt4all.zig](https://github.com/renerocksai/gpt4all.zig) - Zig build for a terminal-based chat client for an assistant-style large language model with ~800k GPT-3.5-Turbo Generations based on LLaMA.
+- [SMC17/safetensors-zig](https://github.com/SMC17/safetensors-zig) - Pure-Zig HuggingFace safetensors reader; ~5x faster than the Rust upstream on Llama-shape parse fixtures. AGPL-3.0.
+- [SMC17/tokenizers-zig](https://github.com/SMC17/tokenizers-zig) - Pure-Zig HuggingFace tokenizers covering BPE / WordPiece / Unigram with full HF Encoding parity, sub-token offsets, and a 600-iter property fuzz. AGPL-3.0.
+- [SMC17/vllm-zig](https://github.com/SMC17/vllm-zig) - LLM serving substrate. Real TinyLlama forward pass through Zig kernels: RoPE + GQA + KV cache + multi-thread SIMD matmul + streaming. AGPL-3.0.
+- [SMC17/faiss-zig](https://github.com/SMC17/faiss-zig) - Pure-Zig vector similarity search; Flat + HNSW + IVFFlat + IVFPQ. AGPL-3.0.
 
 ### Machine Learning
 


### PR DESCRIPTION
Adding four single-purpose Zig 0.16 libraries that compose into an end-to-end CPU LLM inference path. All AGPL-3.0, single-binary, libc-only, with reproducible benchmarks in each repo.

- **safetensors-zig** — HuggingFace safetensors reader (~5x faster than the Rust upstream on Llama-shape fixtures)
- **tokenizers-zig** — BPE / WordPiece / Unigram with full HF Encoding parity (189 tests + 600-iter property fuzz)
- **vllm-zig** — TinyLlama forward pass (RoPE + GQA + KV cache + multi-thread SIMD matmul)
- **faiss-zig** — vector similarity (Flat + HNSW + IVFFlat + IVFPQ)

Composition write-up: https://smc17.github.io/stax-blog/lab/ai-inference-zig-stack.html

Each repo carries pre-1.0 / "honest non-claims" framing in the README — happy to adjust phrasing if the awesome-zig style guide prefers different wording.