### PR TITLE
Liquidz - Liquid template system in Zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [im-ng/zero](https://github.com/im-ng/zero) - Simple and opinionated web framework written in Zig and aims to make microservices development in Zig easier.
 - [GuneshRaj/zigar](https://github.com/GuneshRaj/zigar) - Zigar is a web application framework for Zig that supports ASP / JSP-like template syntax with ASP-style tags.
 - [llllOllOOll/spider](https://github.com/llllOllOOll/spider) - A web framework for Zig with a focus on ergonomics and performance.
-- [brmassa/liquidz](https://github.com/brmassa/liquidz) - A [Liquid template language](https://shopify.github.io/liquid/) implementation in Zig.
+- [brmassa/liquidz](https://gitlab.com/brmassa/liquidz) - A [Liquid template language](https://shopify.github.io/liquid/) implementation in Zig.
 
 ### Web3 Framework
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [im-ng/zero](https://github.com/im-ng/zero) - Simple and opinionated web framework written in Zig and aims to make microservices development in Zig easier.
 - [GuneshRaj/zigar](https://github.com/GuneshRaj/zigar) - Zigar is a web application framework for Zig that supports ASP / JSP-like template syntax with ASP-style tags.
 - [llllOllOOll/spider](https://github.com/llllOllOOll/spider) - A web framework for Zig with a focus on ergonomics and performance.
+- [brmassa/liquidz](https://github.com/brmassa/liquidz) - A [Liquid template language](https://shopify.github.io/liquid/) implementation in Zig.
 
 ### Web3 Framework
 


### PR DESCRIPTION
I've implemented the HTML Liquid template at https://gitlab.com/brmassa/liquidz. It even runs the official Shopify test suite to guarantee the specs.

Local `make all` returned

```
  README.md:1:1
  ⚠  574:68  Text "HuggingFace" should be written as "Hugging Face" (if referring to the technology)  remark-lint:awesome-spell-check
  ⚠  575:66  Text "HuggingFace" should be written as "Hugging Face" (if referring to the technology)  remark-lint:awesome-spell-check
  ✖    1:1   Awesome list must reside in a valid git repository                                       remark-lint:awesome-github
```

nothing related to this PR