### PR TITLE
add nDimensional/zig-flatbuffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [travisstaloch/protobuf-zig](https://github.com/travisstaloch/protobuf-zig) - A protocol buffers implementation in Zig.
 - [Arwalk/zig-protobuf](https://github.com/Arwalk/zig-protobuf) - A protobuf 3 implementation for Zig.
 - [mattnite/protobuf](https://github.com/mattnite/protobuf) - A pure-Zig Protocol Buffers library with a standalone .proto parser, build-time code generator, and transport-agnostic RPC stub generation. Supports proto2 and proto3.
+- [nDimensional/zig-flatbuffers](https://github.com/nDimensional/zig-flatbuffers) - FlatBuffers codegen for Zig, in Zig.
 
 ### Date, Time and Timezones
 


### PR DESCRIPTION
My Zig implementation of FlatBuffers, which has picked up a few users and contributions already!

`make all` has a few pre-existing lint errors:

```
  README.md:1:1
  ⚠  576:68  Text "HuggingFace" should be written as "Hugging Face" (if referring to the technology)  remark-lint:awesome-spell-check
  ⚠  577:66  Text "HuggingFace" should be written as "Hugging Face" (if referring to the technology)  remark-lint:awesome-spell-check
  ✖    1:1   The repository should have "awesome" as a GitHub topic                                   remark-lint:awesome-github
  ✖    1:1   The repository should have "awesome-list" as a GitHub topic                              remark-lint:awesome-github

  2 warnings
  2 errors

make: *** [awesome-lint] Error 1
```