### PR TITLE
Add zigllm to Large Language Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 
 - [cgbur/LLaMa2.zig](https://github.com/cgbur/llama2.zig) - Inference LLaMA 2 in one file of pure Zig.
 - [clebert/LLaMa2.zig](https://github.com/clebert/llama2.zig) - Inference LLaMA 2 in pure Zig.
+- [cognisoc/zigllm](https://github.com/cognisoc/zigllm) - Educational: build an LLM in Zig from scratch — tensors to text generation.
 - [CogitatorTech/zigformer](https://github.com/CogitatorTech/zigformer) - ZigFormer is a transformer-based LLM implemented in pure Zig.
 - [EugenHotaj/zig_gpt2](https://github.com/EugenHotaj/zig_gpt2) - Neural Network Inference Engine in Zig. GPT2 inference engine written in Zig. The inference engine can run [NanoGPT](https://github.com/karpathy/nanoGPT).
 - [nullclaw/nullclaw](https://github.com/nullclaw/nullclaw) - Fastest, smallest, and fully autonomous AI assistant infrastructure written in Zig.

--- a/README.md
+++ b/README.md
@@ -567,8 +567,8 @@ If you find a well-maintained library that is not yet included here, welcome to 
 
 - [cgbur/LLaMa2.zig](https://github.com/cgbur/llama2.zig) - Inference LLaMA 2 in one file of pure Zig.
 - [clebert/LLaMa2.zig](https://github.com/clebert/llama2.zig) - Inference LLaMA 2 in pure Zig.
-- [cognisoc/zigllm](https://github.com/cognisoc/zigllm) - Educational: build an LLM in Zig from scratch — tensors to text generation.
 - [CogitatorTech/zigformer](https://github.com/CogitatorTech/zigformer) - ZigFormer is a transformer-based LLM implemented in pure Zig.
+- [cognisoc/zigllm](https://github.com/cognisoc/zigllm) - Educational: build an LLM in Zig from scratch — tensors to text generation.
 - [EugenHotaj/zig_gpt2](https://github.com/EugenHotaj/zig_gpt2) - Neural Network Inference Engine in Zig. GPT2 inference engine written in Zig. The inference engine can run [NanoGPT](https://github.com/karpathy/nanoGPT).
 - [nullclaw/nullclaw](https://github.com/nullclaw/nullclaw) - Fastest, smallest, and fully autonomous AI assistant infrastructure written in Zig.
 - [ollama-zig](https://github.com/dravenk/ollama-zig) - Ollama Zig library.


### PR DESCRIPTION
## Summary
- Add [cognisoc/zigllm](https://github.com/cognisoc/zigllm) to the **Large Language Model** section.

## About zigllm
Educational LLM project written in pure Zig. Walks through building a language model from scratch — from tensor ops to text generation — to teach the internals of transformer-based inference in a small, readable codebase.

- License: MIT
- Repo: https://github.com/cognisoc/zigllm
- Topics: zig, llm, machine-learning, transformers, educational