### PR TITLE
Add zoptia0regex (Zig regex / RE2 library) to String Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [ziglibs/known-folders](https://github.com/ziglibs/known-folders) - Provides access to well-known folders across several operating systems.
 - [tiehuis/zig-regex](https://github.com/tiehuis/zig-regex) - A regex implementation for the Zig programming language.
 - [shaik-abdul-thouhid/ezi-gex](https://github.com/shaik-abdul-thouhid/ezi-gex) - Unicode-aware regex engine for Zig with runtime and comptime compilation, full \p{} Unicode property support, named captures, and custom pluggable backends (engines).
+- [zoptia/zoptia0regex](https://github.com/zoptia/zoptia0regex) - A regular-expression (regex) library — a faithful, linear-time port of Go's regexp (RE2), proven byte-for-byte identical to Go via ~30k differential tests.
 - [xcaeser/glob.zig](https://github.com/xcaeser/glob.zig) - Fast and reliable glob pattern matching in pure Zig.
 - [jecolon/ziglyph](https://github.com/jecolon/ziglyph) - Unicode text processing for the Zig programming language.
 - [kubkon/zig-yaml](https://github.com/kubkon/zig-yaml) - YAML parser for Zig.


### PR DESCRIPTION
Adds [zoptia0regex](https://github.com/zoptia/zoptia0regex) under **String Processing**.

It's a regular-expression library for Zig: a faithful port of Go's `regexp` (Russ Cox's RE2 design) — linear-time / ReDoS-proof, with all three of Go's engines (one-pass, bitstate, Pike VM). It's verified by ~30k differential tests against the real Go `regexp` (byte-for-byte identical, zero leaks, replayed in CI), and benchmarks ~11% faster than Go on average.

- Apache-2.0, Zig 0.16, `build.zig.zon` package.
- Entry follows the existing list format.