### PR TITLE
Add user529/zora to Network section

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ If you find a well-maintained library that is not yet included here, welcome to 
 
 ### Network
 
+- [user529/zora](https://github.com/user529/zora) - Telegram bot server that runs hot-reloadable Lua 5.4 rules, with coroutine-based async I/O, SQLite-backed state, and a durable scheduler. Targets Linux and FreeBSD.
 - [Nyarum/zigtgshka](https://github.com/Nyarum/zigtgshka) - Memory-safe, high-performance Telegram Bot API library for Zig with zero-cost abstractions and comprehensive examples.
 - [sleep3r/mtproto.zig](https://github.com/sleep3r/mtproto.zig) - High-performance Telegram MTProto proxy written in Zig.
 - [Vexu/routez](https://github.com/Vexu/routez) - HTTP server for Zig.

--- a/README.md
+++ b/README.md
@@ -424,7 +424,6 @@ If you find a well-maintained library that is not yet included here, welcome to 
 
 ### Network
 
-- [user529/zora](https://github.com/user529/zora) - Telegram bot server that runs hot-reloadable Lua 5.4 rules, with coroutine-based async I/O, SQLite-backed state, and a durable scheduler. Targets Linux and FreeBSD.
 - [Nyarum/zigtgshka](https://github.com/Nyarum/zigtgshka) - Memory-safe, high-performance Telegram Bot API library for Zig with zero-cost abstractions and comprehensive examples.
 - [sleep3r/mtproto.zig](https://github.com/sleep3r/mtproto.zig) - High-performance Telegram MTProto proxy written in Zig.
 - [Vexu/routez](https://github.com/Vexu/routez) - HTTP server for Zig.
@@ -453,6 +452,8 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [zigcord](https://codeberg.org/lipfang/zigcord) - Typed Discord API for Zig.
 - [zquic](https://github.com/ch4r10t33r/zquic) - QUIC transport protocol (RFC 9000/9001/9002) with HTTP/3 and QPACK support, written in pure Zig with zero C dependencies.
 - [zigtls](https://github.com/Geun-Oh/zigtls) - Zig-native TLS Implementation library for edge/load-balancer event loops, with BoGo strict, interop, and reliability gates.
+- [zora](https://github.com/user529/zora) - Telegram bot server that runs hot-reloadable Lua 5.4 rules, with coroutine-based async I/O, SQLite-backed state, and a durable scheduler. Targets Linux and FreeBSD.
+
 
 ### Browser
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,6 @@ If you find a well-maintained library that is not yet included here, welcome to 
 - [zigtls](https://github.com/Geun-Oh/zigtls) - Zig-native TLS Implementation library for edge/load-balancer event loops, with BoGo strict, interop, and reliability gates.
 - [zora](https://github.com/user529/zora) - Telegram bot server that runs hot-reloadable Lua 5.4 rules, with coroutine-based async I/O, SQLite-backed state, and a durable scheduler. Targets Linux and FreeBSD.
 
-
 ### Browser
 
 - [lightpanda-io/browser](https://github.com/lightpanda-io/browser) - Headless browser designed for AI and automation.


### PR DESCRIPTION
Adds [zora](https://github.com/user529/zora) to Network & Web - Networking.

zora is a Telegram bot server written in Zig. Bot logic lives in Lua 5.4
rules that are hot-reloaded on change (inotify/kqueue) with no restart. 