### PR TITLE
Add zjolt, zecs, ztypeset, zozz, zmeshopt, zcgltf and zrecast to FFI Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,10 @@ Zig wrappers and bindings for existing C/C++ libraries, providing idiomatic Zig 
 - [arshidkv12/zig-php](https://github.com/arshidkv12/zig-php) - Write PHP extension in Zig.
 - [OnlyF0uR/pqc-zig](https://github.com/OnlyF0uR/pqc-zig) - Zig bindings and abstractions for [PQClean](https://github.com/PQClean/PQClean/), post-quantum cryptography.
 - [happystraw/phpz](https://github.com/happystraw/phpz) - Build PHP extensions with Zig.
+- [pedronaugusto/zjolt](https://github.com/pedronaugusto/zjolt) - Zig bindings for Jolt Physics — the whole runtime, from shapes and the step to constraints, characters, vehicles, ragdolls, soft bodies and hair. AI-assisted.
+- [pedronaugusto/zecs](https://github.com/pedronaugusto/zecs) - Zig bindings for flecs, Sander Mertens's entity component system — vendored byte for byte. AI-assisted.
+- [pedronaugusto/ztypeset](https://github.com/pedronaugusto/ztypeset) - Text shaping and glyph rasterisation for Zig: vendored FreeType, HarfBuzz, SheenBidi and libunibreak behind one package. AI-assisted.
+- [pedronaugusto/zozz](https://github.com/pedronaugusto/zozz) - Zig bindings for the ozz-animation runtime — skeletal animation sampling. AI-assisted.
 
 ### Build with Zig
 

--- a/README.md
+++ b/README.md
@@ -765,6 +765,8 @@ Zig wrappers and bindings for existing C/C++ libraries, providing idiomatic Zig 
 - [pedronaugusto/zecs](https://github.com/pedronaugusto/zecs) - Zig bindings for flecs, Sander Mertens's entity component system — vendored byte for byte. AI-assisted.
 - [pedronaugusto/ztypeset](https://github.com/pedronaugusto/ztypeset) - Text shaping and glyph rasterisation for Zig: vendored FreeType, HarfBuzz, SheenBidi and libunibreak behind one package. AI-assisted.
 - [pedronaugusto/zozz](https://github.com/pedronaugusto/zozz) - Zig bindings for the ozz-animation runtime — skeletal animation sampling. AI-assisted.
+- [pedronaugusto/zmeshopt](https://github.com/pedronaugusto/zmeshopt) - Zig bindings for meshoptimizer — mesh indexing, optimization, simplification, compression and meshlet building. AI-assisted.
+- [pedronaugusto/zcgltf](https://github.com/pedronaugusto/zcgltf) - Zig bindings for cgltf — glTF 2.0 parsing, validation, accessor reading and writing. AI-assisted.
 
 ### Build with Zig
 

--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ Zig wrappers and bindings for existing C/C++ libraries, providing idiomatic Zig 
 - [pedronaugusto/zozz](https://github.com/pedronaugusto/zozz) - Zig bindings for the ozz-animation runtime — skeletal animation sampling. AI-assisted.
 - [pedronaugusto/zmeshopt](https://github.com/pedronaugusto/zmeshopt) - Zig bindings for meshoptimizer — mesh indexing, optimization, simplification, compression and meshlet building. AI-assisted.
 - [pedronaugusto/zcgltf](https://github.com/pedronaugusto/zcgltf) - Zig bindings for cgltf — glTF 2.0 parsing, validation, accessor reading and writing. AI-assisted.
+- [pedronaugusto/zrecast](https://github.com/pedronaugusto/zrecast) - Zig bindings for recastnavigation — navmesh baking, path queries, off-mesh links, dynamic obstacles through a tile cache and crowd steering. AI-assisted.
 
 ### Build with Zig
 


### PR DESCRIPTION
Adds seven packages I maintain to the FFI Bindings section: zjolt (Jolt Physics), zecs (flecs), ztypeset (FreeType + HarfBuzz + SheenBidi + libunibreak), zozz (ozz-animation), zmeshopt (meshoptimizer), zcgltf (cgltf) and zrecast (recastnavigation). All seven vendor their upstream pinned and unpatched, expose the library through a C ABI with a Zig API on top, and run CI on Linux, macOS and Windows (both gnu and msvc). Labelled AI-assisted per contributing.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `zjolt`, `zecs`, `ztypeset`, `zozz`, `zmeshopt`, `zcgltf`, and `zrecast` to the FFI Bindings project list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->